### PR TITLE
Remove unnecessary support for approve intent

### DIFF
--- a/model/transactionRequest.ts
+++ b/model/transactionRequest.ts
@@ -31,7 +31,7 @@ export class TransactionRequest {
     */
     'store'?: boolean;
     /**
-    * Defines the intent of this API call. This determines the desired initial state of the transaction.  * `approve` - Captures approval for the transaction from the user but does not authorize it. This is only available to payment methods that require explicit approval, like PayPal. * `authorize` - (Default) Optionally approves and then authorizes a transaction but does not capture the funds. * `capture` - Optionally approves and then authorizes and captures the funds of the transaction.
+    * Defines the intent of this API call. This determines the desired initial state of the transaction.  * `authorize` - (Default) Optionally approves and then authorizes a transaction but does not capture the funds. * `capture` - Optionally approves and then authorizes and captures the funds of the transaction.
     */
     'intent'?: TransactionRequest.IntentEnum;
     /**
@@ -89,7 +89,6 @@ export class TransactionRequest {
 
 export namespace TransactionRequest {
     export enum IntentEnum {
-        Approve = <any> 'approve',
         Authorize = <any> 'authorize',
         Capture = <any> 'capture'
     }


### PR DESCRIPTION
Remove support for `approve` intent as it is not longer necessary. We now only support `capture` and `authorize` intents.