### PR TITLE
feat(environments): Change to use new sandbox and production environments

### DIFF
--- a/sdk/client.test.ts
+++ b/sdk/client.test.ts
@@ -25,6 +25,15 @@ describe('#constructor', () => {
     expect(client.baseUrl).toBe('https://api.test.gr4vy.app')
   })
 
+  test('it should work with a gr4vy ID and an environment', () => {
+    const client = new Client({
+      privateKey,
+      gr4vyId: 'test',
+      environment: 'sandbox',
+    })
+    expect(client.baseUrl).toBe('https://api.sandbox.test.gr4vy.app')
+  })
+
   test('it should work with a base URL', () => {
     const client = new Client({
       privateKey,

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -66,9 +66,11 @@ class Client {
     this.apis = []
     this.authentication = new Authentication(options.privateKey)
     this.debug = options.debug || false
+
+    const apiPrefix = options.environment === 'sandbox' ? 'sandbox.' : ''
     this.baseUrl = options.baseUrl
       ? options.baseUrl
-      : `https://api.${options.gr4vyId}.gr4vy.app`
+      : `https://api.${apiPrefix}${options.gr4vyId}.gr4vy.app`
 
     // Buyers
     const ba = new BuyersApi(this.baseUrl)
@@ -235,12 +237,14 @@ type Options =
       privateKey: string
       baseUrl?: string
       debug?: boolean
+      environment?: 'production' | 'sandbox'
     }
   | {
       gr4vyId?: string
       privateKey: string
       baseUrl: string
       debug?: boolean
+      environment?: 'production' | 'sandbox'
     }
 
 export default Client


### PR DESCRIPTION
Adds new `environment` option to SDK to change API URL used.

* `environment` set to `production` or left blank (default) will result in `api.{gr4vy_id}.gr4vy.app`.
* `environment` set to `sandbox` will result in `api.sandbox.{gr4vy_id}.gr4vy.app`.

The `environment` is ignored when the `baseUrl` is set.

# Remaining todos.

- [ ] Regenerate SDK to include removal of `credentials_mode` and `environment(s)` from API requests. See https://github.com/gr4vy/gr4vy-openapi/pull/84
