### PR TITLE
feat: Add support for checkout sessions to Embed tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,44 @@ To create a token for Gr4vy Embed, call the `client.getEmbedToken()` function
 with the amount, currency, and optional buyer information for Gr4vy Embed.
 
 ```js
+// generate a session to tie any transactions to
+const response = await this.newCheckoutSession()
+// generate the token
 const token = await client.getEmbedToken({
   amount: 1299,
   currency: 'USD',
   buyerExternalIdentifier: 'user-1234',
+  checkoutSessionId: response.body.id,
   // or: buyerId: ...
+})
+
+// or to combine both calls in one
+const { token, checkoutSession } =
+  await client.getEmbedTokenWithCheckoutSession(embedParams)
+```
+
+You can now pass this token to your front end where it can be used to
+authenticate Gr4vy Embed.
+
+### Refreshing a token
+
+To get a new token with a new expiration date, or to add new data to a token, without losing the checkout session ID,
+you can call the `updateEmbedToken` method again with the original token and the new data. Your checkout session will
+automatically be added to the same token.
+
+```js
+const token = await client.updateEmbedToken(oldToken, {
+  amount: 1299,
+  currency: 'USD',
+  buyerExternalIdentifier: 'user-1234',
 })
 ```
 
-You can now pass this token to your frontend where it can be used to
-authenticate Gr4vy Embed.
+### Additional data
 
-The `buyerId` and `buyerExternalIdentifier` fields can be used to allow the
-token to pull in previously stored payment methods for a user. A buyer needs to
-be created before it can be used in this way.
+Additional data can be added to a token. The `buyerId` and `buyerExternalIdentifier`
+fields can be used to allow the token to pull in previously stored payment methods for a user.
+A buyer needs to be created before it can be used in this way.
 
 ```js
 const buyerRequest = new BuyerRequest()

--- a/model/checkoutSession.ts
+++ b/model/checkoutSession.ts
@@ -10,51 +10,56 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
+import { RequestFile } from './models'
 
 /**
-* A short-lived checkout session.
-*/
+ * A short-lived checkout session.
+ */
 export class CheckoutSession {
-    /**
-    * `checkout-session`.
-    */
-    'type'?: CheckoutSession.TypeEnum;
-    /**
-    * The ID of the Checkout Session.
-    */
-    'id'?: string;
-    /**
-    * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
-    */
-    'expiresAt'?: Date;
+  /**
+   * `checkout-session`.
+   */
+  'type'?: CheckoutSession.TypeEnum
+  /**
+   * The ID of the Checkout Session.
+   */
+  'id'?: string
+  /**
+   * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
+   */
+  'expiresAt'?: Date
 
-    static discriminator: string | undefined = undefined;
+  static discriminator: string | undefined = undefined
 
-    static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
-        {
-            "name": "type",
-            "baseName": "type",
-            "type": "CheckoutSession.TypeEnum"
-        },
-        {
-            "name": "id",
-            "baseName": "id",
-            "type": "string"
-        },
-        {
-            "name": "expiresAt",
-            "baseName": "expires_at",
-            "type": "Date"
-        }    ];
+  static attributeTypeMap: Array<{
+    name: string
+    baseName: string
+    type: string
+  }> = [
+    {
+      name: 'type',
+      baseName: 'type',
+      type: 'CheckoutSession.TypeEnum',
+    },
+    {
+      name: 'id',
+      baseName: 'id',
+      type: 'string',
+    },
+    {
+      name: 'expiresAt',
+      baseName: 'expires_at',
+      type: 'Date',
+    },
+  ]
 
-    static getAttributeTypeMap() {
-        return CheckoutSession.attributeTypeMap;
-    }
+  static getAttributeTypeMap() {
+    return CheckoutSession.attributeTypeMap
+  }
 }
 
 export namespace CheckoutSession {
-    export enum TypeEnum {
-        CheckoutSession = <any> 'checkout-session'
-    }
+  export enum TypeEnum {
+    CheckoutSession = <any>'checkout-session',
+  }
 }

--- a/model/checkoutSession.ts
+++ b/model/checkoutSession.ts
@@ -10,56 +10,51 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models'
+import { RequestFile } from './models';
 
 /**
- * A short-lived checkout session.
- */
+* A short-lived checkout session.
+*/
 export class CheckoutSession {
-  /**
-   * `checkout-session`.
-   */
-  'type'?: CheckoutSession.TypeEnum
-  /**
-   * The ID of the Checkout Session.
-   */
-  'id'?: string
-  /**
-   * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
-   */
-  'expiresAt'?: Date
+    /**
+    * `checkout-session`.
+    */
+    'type'?: CheckoutSession.TypeEnum;
+    /**
+    * The ID of the Checkout Session.
+    */
+    'id'?: string;
+    /**
+    * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
+    */
+    'expiresAt'?: Date;
 
-  static discriminator: string | undefined = undefined
+    static discriminator: string | undefined = undefined;
 
-  static attributeTypeMap: Array<{
-    name: string
-    baseName: string
-    type: string
-  }> = [
-    {
-      name: 'type',
-      baseName: 'type',
-      type: 'CheckoutSession.TypeEnum',
-    },
-    {
-      name: 'id',
-      baseName: 'id',
-      type: 'string',
-    },
-    {
-      name: 'expiresAt',
-      baseName: 'expires_at',
-      type: 'Date',
-    },
-  ]
+    static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
+        {
+            "name": "type",
+            "baseName": "type",
+            "type": "CheckoutSession.TypeEnum"
+        },
+        {
+            "name": "id",
+            "baseName": "id",
+            "type": "string"
+        },
+        {
+            "name": "expiresAt",
+            "baseName": "expires_at",
+            "type": "Date"
+        }    ];
 
-  static getAttributeTypeMap() {
-    return CheckoutSession.attributeTypeMap
-  }
+    static getAttributeTypeMap() {
+        return CheckoutSession.attributeTypeMap;
+    }
 }
 
 export namespace CheckoutSession {
-  export enum TypeEnum {
-    CheckoutSession = <any>'checkout-session',
-  }
+    export enum TypeEnum {
+        CheckoutSession = <any> 'checkout-session'
+    }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
     "prettier": "^2.3.1",
+    "timekeeper": "^2.2.0",
     "typescript": "^5.0.2"
   },
   "bugs": {

--- a/sdk/authentication.test.ts
+++ b/sdk/authentication.test.ts
@@ -118,7 +118,7 @@ describe('.parseJSW', () => {
       checkoutSessionId
     )
 
-    timekeeper.travel(Date.now() + 1000)
+    timekeeper.travel(Date.now() + 1000 * 90)
 
     const token2 = await auth.updateJWS(token1, '1m')
 

--- a/sdk/authentication.test.ts
+++ b/sdk/authentication.test.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
 import snakecaseKeys from 'snakecase-keys'
+import timekeeper from 'timekeeper'
 import { version } from '../package.json'
 import Authentication, { JWTScope } from './authentication'
 
@@ -32,6 +33,8 @@ const embedParams = {
     },
   ],
 }
+
+const checkoutSessionId = '0ebde6a1-f66c-43ea-bb8b-73751864c604'
 
 describe('.getJWS', () => {
   test('it should create a valid signed JWT token', async () => {
@@ -81,5 +84,55 @@ describe('.getJWS', () => {
 
     expect(decoded.payload.scopes).toEqual(['*.read'])
     expect(decoded.payload.embed).toBeUndefined()
+  })
+
+  test('it should take an optional checkout session ID', async () => {
+    const checkoutSessionId = 'id'
+
+    const auth = new Authentication(privateKey)
+    const jws = await auth.getJWS(
+      [JWTScope.ReadAll],
+      '1m',
+      embedParams,
+      checkoutSessionId
+    )
+
+    const decoded = jwt.verify(jws, privateKey, {
+      algorithms: ['ES512'],
+      complete: true,
+    })
+
+    expect(decoded.payload.checkout_session_id).toEqual(checkoutSessionId)
+  })
+})
+
+describe('.parseJSW', () => {
+  test('it should decode a token', async () => {
+    timekeeper.freeze(Date.now())
+
+    const auth = new Authentication(privateKey)
+    const token1 = await auth.getJWS(
+      [JWTScope.Embed],
+      '1m',
+      embedParams,
+      checkoutSessionId
+    )
+
+    timekeeper.travel(Date.now() + 1000)
+
+    const token2 = await auth.updateJWS(token1, '1m')
+
+    const decoded1 = jwt.decode(token1, { complete: true })
+    const decoded2 = jwt.decode(token2, { complete: true })
+
+    expect(decoded2.header).toEqual(decoded1.header)
+    expect(decoded2.payload.scopes).toEqual(decoded1.payload.scopes)
+    expect(decoded2.payload.embed).toEqual(decoded1.payload.embed)
+    expect(decoded2.payload.checkout_session_id).toEqual(
+      decoded1.payload.checkout_session_id
+    )
+    expect(decoded2.payload.iat).toBeGreaterThan(decoded1.payload.iat)
+    expect(decoded2.payload.exp).toBeGreaterThan(decoded1.payload.exp)
+    expect(decoded2.payload.nbf).toBeGreaterThan(decoded1.payload.nbf)
   })
 })

--- a/sdk/authentication.ts
+++ b/sdk/authentication.ts
@@ -45,6 +45,7 @@ class Authentication {
   public async updateJWS(token: string, expiresIn = '30s'): Promise<string> {
     const payload = jwt.verify(token, this.privateKey, {
       algorithms: ['ES512'],
+      ignoreExpiration: true,
     })
     const { scopes, checkout_session_id: checkoutSessionId, embed } = payload
     return this.getJWS(scopes, expiresIn, embed, checkoutSessionId)

--- a/sdk/authentication.ts
+++ b/sdk/authentication.ts
@@ -18,10 +18,15 @@ class Authentication {
   public async getJWS(
     scopes: JWTScopes = [JWTScope.ReadAll, JWTScope.WriteAll],
     expiresIn = '30s',
-    embed?: EmbedParams
+    embed?: EmbedParams,
+    checkoutSessionId?: string
   ): Promise<string> {
     const keyid: string = await this.getKeyId()
     const claims = { scopes }
+
+    if (checkoutSessionId) {
+      claims['checkout_session_id'] = checkoutSessionId
+    }
 
     if (scopes.includes(JWTScope.Embed) && embed) {
       claims['embed'] = snakeCaseKeys(embed, { exclude: ['metadata'] })
@@ -35,6 +40,14 @@ class Authentication {
       notBefore: '0s',
       issuer,
     })
+  }
+
+  public async updateJWS(token: string, expiresIn = '30s'): Promise<string> {
+    const payload = jwt.verify(token, this.privateKey, {
+      algorithms: ['ES512'],
+    })
+    const { scopes, checkout_session_id: checkoutSessionId, embed } = payload
+    return this.getJWS(scopes, expiresIn, embed, checkoutSessionId)
   }
 
   public async getKeyId(): Promise<string> {

--- a/sdk/authentication.ts
+++ b/sdk/authentication.ts
@@ -18,7 +18,7 @@ class Authentication {
   public async getJWS(
     scopes: JWTScopes = [JWTScope.ReadAll, JWTScope.WriteAll],
     expiresIn = '30s',
-    embed?: EmbedParams,
+    embedParams?: EmbedParams,
     checkoutSessionId?: string
   ): Promise<string> {
     const keyid: string = await this.getKeyId()
@@ -28,8 +28,8 @@ class Authentication {
       claims['checkout_session_id'] = checkoutSessionId
     }
 
-    if (scopes.includes(JWTScope.Embed) && embed) {
-      claims['embed'] = snakeCaseKeys(embed, { exclude: ['metadata'] })
+    if (scopes.includes(JWTScope.Embed) && embedParams) {
+      claims['embed'] = snakeCaseKeys(embedParams, { exclude: ['metadata'] })
     }
 
     return jwt.sign(claims, this.privateKey, {
@@ -42,13 +42,24 @@ class Authentication {
     })
   }
 
-  public async updateJWS(token: string, expiresIn = '30s'): Promise<string> {
+  public async updateJWS(
+    token: string,
+    expiresIn = '30s',
+    embedParams?: EmbedParams
+  ): Promise<string> {
     const payload = jwt.verify(token, this.privateKey, {
       algorithms: ['ES512'],
       ignoreExpiration: true,
     })
+
     const { scopes, checkout_session_id: checkoutSessionId, embed } = payload
-    return this.getJWS(scopes, expiresIn, embed, checkoutSessionId)
+
+    return this.getJWS(
+      scopes,
+      expiresIn,
+      embedParams ?? embed,
+      checkoutSessionId
+    )
   }
 
   public async getKeyId(): Promise<string> {

--- a/sdk/client.test.ts
+++ b/sdk/client.test.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken'
 import snakecaseKeys from 'snakecase-keys'
+import timekeeper from 'timekeeper'
 import Client from './client'
 
 const privateKey = `-----BEGIN PRIVATE KEY-----
@@ -79,6 +80,29 @@ describe('.getEmbedToken()', () => {
     expect(decoded.header.kid).toBe(thumbprint)
     expect(decoded.payload.scopes).toEqual(['embed'])
     expect(decoded.payload.embed).toEqual(snakecaseKeys(embedParams))
+  })
+})
+
+describe('.updateEmbedToken()', () => {
+  test('it should update a valid signed JWT token', async () => {
+    const client = new Client({ privateKey, gr4vyId: 'demo' })
+    timekeeper.freeze(Date.now())
+    const token1 = await client.getEmbedToken(embedParams)
+    timekeeper.travel(Date.now() + 1000)
+    const token2 = await client.updateEmbedToken(token1)
+
+    const decoded1 = jwt.decode(token1, { complete: true })
+    const decoded2 = jwt.decode(token2, { complete: true })
+
+    expect(decoded2.header).toEqual(decoded1.header)
+    expect(decoded2.payload.scopes).toEqual(decoded1.payload.scopes)
+    expect(decoded2.payload.embed).toEqual(decoded1.payload.embed)
+    expect(decoded2.payload.checkout_session_id).toEqual(
+      decoded1.payload.checkout_session_id
+    )
+    expect(decoded2.payload.iat).toBeGreaterThan(decoded1.payload.iat)
+    expect(decoded2.payload.exp).toBeGreaterThan(decoded1.payload.exp)
+    expect(decoded2.payload.nbf).toBeGreaterThan(decoded1.payload.nbf)
   })
 })
 

--- a/sdk/client.test.ts
+++ b/sdk/client.test.ts
@@ -106,6 +106,28 @@ describe('.updateEmbedToken()', () => {
   })
 })
 
+describe('.updateBearerToken()', () => {
+  test('it should update a valid signed JWT token', async () => {
+    const client = new Client({ privateKey, gr4vyId: 'demo' })
+    timekeeper.freeze(Date.now())
+    const token1 = await client.getBearerToken()
+    timekeeper.travel(Date.now() + 1000)
+    const token2 = await client.getBearerToken()
+
+    const decoded1 = jwt.decode(token1, { complete: true })
+    const decoded2 = jwt.decode(token2, { complete: true })
+
+    expect(decoded2.header).toEqual(decoded1.header)
+    expect(decoded2.payload.scopes).toEqual(decoded1.payload.scopes)
+    expect(decoded2.payload.checkout_session_id).toEqual(
+      decoded1.payload.checkout_session_id
+    )
+    expect(decoded2.payload.iat).toBeGreaterThan(decoded1.payload.iat)
+    expect(decoded2.payload.exp).toBeGreaterThan(decoded1.payload.exp)
+    expect(decoded2.payload.nbf).toBeGreaterThan(decoded1.payload.nbf)
+  })
+})
+
 describe('.setMerchantAccountId()', () => {
   test('it should set the default header for every request', async () => {
     const client = new Client({

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -285,8 +285,8 @@ class Client {
    * @param args The arguments that were passed to the function
    */
   private async preprocess(fn, args) {
-    this.log(`Gr4vy - Request - ${fn.name.replace('bound ', '.')}:`, ...args)
     await this.attachBearerToken()
+    this.log(`Gr4vy - Request - ${fn.name.replace('bound ', '.')}:`, ...args)
   }
 
   /**
@@ -300,7 +300,8 @@ class Client {
       `Gr4vy - Response - ${fn.name.replace('bound ', '.')} - ${
         data?.response?.statusCode
       }):`,
-      data.body
+      data.body,
+      data.defaultHeaders
     )
   }
 

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -246,6 +246,17 @@ class Client {
   }
 
   /**
+   * Updates a bearer token, keeping any existing claims
+   * but resigning it with a new expiration date.
+   */
+  public async updateBearerToken(
+    token: string,
+    expiresIn = '30s'
+  ): Promise<string> {
+    return this.authentication.updateJWS(token, expiresIn)
+  }
+
+  /**
    * Wrap an API endpoint with pre and post processing
    * @param fn The API endpoint to wrap
    */
@@ -270,7 +281,7 @@ class Client {
    */
   private async preprocess(fn, args) {
     this.log(`Gr4vy - Request - ${fn.name.replace('bound ', '.')}:`, ...args)
-    await this.updateBearerToken()
+    await this.attachBearerToken()
   }
 
   /**
@@ -291,7 +302,7 @@ class Client {
   /**
    * Generates a new authorization token and attaches it to every API.
    */
-  private async updateBearerToken(): Promise<void> {
+  private async attachBearerToken(): Promise<void> {
     const token: string = await this.getBearerToken()
     this.apis.map((api) => (api.accessToken = token))
   }

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -207,9 +207,42 @@ class Client {
     return this.authentication.getJWS(scopes, expiresIn)
   }
 
-  public getEmbedToken(embed: EmbedParams): Promise<string> {
+  /**
+   * Returns a token for use with Embed. This token is limited to 1 hour and
+   * the `embed` scope.
+   *
+   * @param embed An object that's added to the `embed` value in the JWT claim
+   */
+  public getEmbedToken(
+    embed: EmbedParams,
+    checkoutSessionId?: string
+  ): Promise<string> {
     const scopes = [JWTScope.Embed]
-    return this.authentication.getJWS(scopes, '1h', embed)
+    return this.authentication.getJWS(scopes, '1h', embed, checkoutSessionId)
+  }
+
+  /**
+   * Returns a token for use with Embed which ties all transactions to Embed. This
+   * will automatically create a checkout session and add it to the claims in the JWT. This
+   * then ties all the transactions to this token.
+   *
+   * This token is limited to 1 hour and the `embed` scope
+   *
+   * @param embed An object that's added to the `embed` value in the JWT claim
+   */
+  public async getEmbedTokenWithCheckoutSession(
+    embed: EmbedParams
+  ): Promise<string> {
+    const response = await this.newCheckoutSession()
+    return this.getEmbedToken(embed, response.body.id)
+  }
+
+  /**
+   * Updates an Embed token, keeping any existing claims
+   * but resigning it with a new expiration date.
+   */
+  public async updateEmbedToken(token: string): Promise<string> {
+    return this.authentication.updateJWS(token, '1h')
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,6 +4536,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+timekeeper@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.2.0.tgz#9645731fce9e3280a18614a57a9d1b72af3ca368"
+  integrity sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"


### PR DESCRIPTION
Re TA-4565

This adds the ability to generate a new Embed token which will have a checkout session ID as one of it's claims.

```js
const { token, checkoutSession } = await client.getEmbedTokenWithCheckoutSession({
  amount: 1299,
  currency: 'USD',
  buyerExternalIdentifier: 'user-1234',
  // etc
})
```

This function has the same signature as `getEmbedToken` but automatically generates a checkout session and then adds it to the JWT claims. It also returns the checkout session.

This also adds a new `updateEmbedToken` function that can be used to renew the Embed token with a new expiration date while keeping all scopes and checkout sessions the same. What it does not do is allow for extending the checkout session.

```js
const newToken = await client.updateEmbedToken(token, {
  amount: 999, // new amount
  currency: 'USD',
  buyerExternalIdentifier: 'user-1234',
  // etc
})
```

## Todos

* I still need to add more details to the README and the public docs once we decide on the final usage.
* I think we can update the `updateEmbedToken` eventually to also update the checkout session, extending the checkout session expiry date, and maybe even automatically update any data ON the checkout session (instead of putting them in the JWT).

## Questions

There's a few alternative ways to implement `getEmbedTokenWithCheckoutSession`

1. `getEmbedToken()` with an optional flag to generate the checkout session ID
2. `getEmbedToken()` but the checkout session is always generated


