### PR TITLE
feat: Add new checkout session endpoint + missing properties

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -55,9 +55,11 @@ model/cardSchemeDefinition.ts
 model/cardSchemeDefinitions.ts
 model/cartItem.ts
 model/checkoutSession.ts
+model/checkoutSessionCreateRequest.ts
 model/checkoutSessionFieldsPaymentMethod.ts
 model/checkoutSessionRequest.ts
 model/checkoutSessionSecureFieldsUpdate.ts
+model/checkoutSessionUpdateRequest.ts
 model/connection.ts
 model/connectionDefinition.ts
 model/connectionDefinitions.ts

--- a/api/checkoutSessionsApi.ts
+++ b/api/checkoutSessionsApi.ts
@@ -16,7 +16,9 @@ import http from 'http';
 
 /* tslint:disable:no-unused-locals */
 import { CheckoutSession } from '../model/checkoutSession';
+import { CheckoutSessionCreateRequest } from '../model/checkoutSessionCreateRequest';
 import { CheckoutSessionSecureFieldsUpdate } from '../model/checkoutSessionSecureFieldsUpdate';
+import { CheckoutSessionUpdateRequest } from '../model/checkoutSessionUpdateRequest';
 import { Error401Unauthorized } from '../model/error401Unauthorized';
 import { Error404NotFound } from '../model/error404NotFound';
 import { Error409DuplicateRecord } from '../model/error409DuplicateRecord';
@@ -243,8 +245,9 @@ export class CheckoutSessionsApi {
     /**
      * Creates a new Checkout Session.
      * @summary New checkout session
+     * @param checkoutSessionCreateRequest 
      */
-    public async newCheckoutSession (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: CheckoutSession;  }> {
+    public async newCheckoutSession (checkoutSessionCreateRequest?: CheckoutSessionCreateRequest, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: CheckoutSession;  }> {
         const localVarPath = this.basePath + '/checkout/sessions';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
@@ -268,6 +271,81 @@ export class CheckoutSessionsApi {
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
+            body: ObjectSerializer.serialize(checkoutSessionCreateRequest, "CheckoutSessionCreateRequest")
+        };
+
+        let authenticationPromise = Promise.resolve();
+        if (this.authentications.BearerAuth.accessToken) {
+            authenticationPromise = authenticationPromise.then(() => this.authentications.BearerAuth.applyToRequest(localVarRequestOptions));
+        }
+        authenticationPromise = authenticationPromise.then(() => this.authentications.default.applyToRequest(localVarRequestOptions));
+
+        let interceptorPromise = authenticationPromise;
+        for (const interceptor of this.interceptors) {
+            interceptorPromise = interceptorPromise.then(() => interceptor(localVarRequestOptions));
+        }
+
+        return interceptorPromise.then(() => {
+            if (Object.keys(localVarFormParams).length) {
+                if (localVarUseFormData) {
+                    (<any>localVarRequestOptions).formData = localVarFormParams;
+                } else {
+                    localVarRequestOptions.form = localVarFormParams;
+                }
+            }
+            return new Promise<{ response: http.IncomingMessage; body: CheckoutSession;  }>((resolve, reject) => {
+                localVarRequest(localVarRequestOptions, (error, response, body) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        body = ObjectSerializer.deserialize(body, "CheckoutSession");
+                        if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                            resolve({ response: response, body: body });
+                        } else {
+                            reject(new HttpError(response, body, response.statusCode));
+                        }
+                    }
+                });
+            });
+        });
+    }
+    /**
+     * Updates a Checkout Session.
+     * @summary Update checkout session
+     * @param checkoutSessionId The unique ID for a Checkout Session.
+     * @param checkoutSessionUpdateRequest 
+     */
+    public async updateCheckoutSession (checkoutSessionId: string, checkoutSessionUpdateRequest?: CheckoutSessionUpdateRequest, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: CheckoutSession;  }> {
+        const localVarPath = this.basePath + '/checkout/sessions/{checkout_session_id}'
+            .replace('{' + 'checkout_session_id' + '}', encodeURIComponent(String(checkoutSessionId)));
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
+        let localVarFormParams: any = {};
+
+        // verify required parameter 'checkoutSessionId' is not null or undefined
+        if (checkoutSessionId === null || checkoutSessionId === undefined) {
+            throw new Error('Required parameter checkoutSessionId was null or undefined when calling updateCheckoutSession.');
+        }
+
+        (<any>Object).assign(localVarHeaderParams, options.headers);
+
+        let localVarUseFormData = false;
+
+        let localVarRequestOptions: localVarRequest.Options = {
+            method: 'PUT',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: ObjectSerializer.serialize(checkoutSessionUpdateRequest, "CheckoutSessionUpdateRequest")
         };
 
         let authenticationPromise = Promise.resolve();

--- a/model/auditLog.ts
+++ b/model/auditLog.ts
@@ -34,6 +34,10 @@ export class AuditLog {
     * The action that was performed.
     */
     'action'?: AuditLog.ActionEnum;
+    /**
+    * The ID of the merchant account this entry was created for.
+    */
+    'merchantAccountId'?: string | null;
     'user'?: AuditLogUser;
     'resource'?: AuditLogResource;
 
@@ -59,6 +63,11 @@ export class AuditLog {
             "name": "action",
             "baseName": "action",
             "type": "AuditLog.ActionEnum"
+        },
+        {
+            "name": "merchantAccountId",
+            "baseName": "merchant_account_id",
+            "type": "string"
         },
         {
             "name": "user",

--- a/model/checkoutSessionCreateRequest.ts
+++ b/model/checkoutSessionCreateRequest.ts
@@ -14,21 +14,9 @@ import { RequestFile } from './models';
 import { CartItem } from './cartItem';
 
 /**
-* A short-lived checkout session.
+* A request to create a checkout session.
 */
-export class CheckoutSession {
-    /**
-    * `checkout-session`.
-    */
-    'type'?: CheckoutSession.TypeEnum;
-    /**
-    * The ID of the Checkout Session.
-    */
-    'id'?: string;
-    /**
-    * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
-    */
-    'expiresAt'?: Date;
+export class CheckoutSessionCreateRequest {
     /**
     * An array of cart items that represents the line items of a transaction.
     */
@@ -42,21 +30,6 @@ export class CheckoutSession {
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "type",
-            "baseName": "type",
-            "type": "CheckoutSession.TypeEnum"
-        },
-        {
-            "name": "id",
-            "baseName": "id",
-            "type": "string"
-        },
-        {
-            "name": "expiresAt",
-            "baseName": "expires_at",
-            "type": "Date"
-        },
-        {
             "name": "cartItems",
             "baseName": "cart_items",
             "type": "Array<CartItem>"
@@ -68,12 +41,7 @@ export class CheckoutSession {
         }    ];
 
     static getAttributeTypeMap() {
-        return CheckoutSession.attributeTypeMap;
+        return CheckoutSessionCreateRequest.attributeTypeMap;
     }
 }
 
-export namespace CheckoutSession {
-    export enum TypeEnum {
-        CheckoutSession = <any> 'checkout-session'
-    }
-}

--- a/model/checkoutSessionUpdateRequest.ts
+++ b/model/checkoutSessionUpdateRequest.ts
@@ -14,21 +14,9 @@ import { RequestFile } from './models';
 import { CartItem } from './cartItem';
 
 /**
-* A short-lived checkout session.
+* A request to update a checkout session.
 */
-export class CheckoutSession {
-    /**
-    * `checkout-session`.
-    */
-    'type'?: CheckoutSession.TypeEnum;
-    /**
-    * The ID of the Checkout Session.
-    */
-    'id'?: string;
-    /**
-    * The date and time when the Checkout Session will expire. By default this will be set to 1 hour from the date of creation.
-    */
-    'expiresAt'?: Date;
+export class CheckoutSessionUpdateRequest {
     /**
     * An array of cart items that represents the line items of a transaction.
     */
@@ -42,21 +30,6 @@ export class CheckoutSession {
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
-            "name": "type",
-            "baseName": "type",
-            "type": "CheckoutSession.TypeEnum"
-        },
-        {
-            "name": "id",
-            "baseName": "id",
-            "type": "string"
-        },
-        {
-            "name": "expiresAt",
-            "baseName": "expires_at",
-            "type": "Date"
-        },
-        {
             "name": "cartItems",
             "baseName": "cart_items",
             "type": "Array<CartItem>"
@@ -68,12 +41,7 @@ export class CheckoutSession {
         }    ];
 
     static getAttributeTypeMap() {
-        return CheckoutSession.attributeTypeMap;
+        return CheckoutSessionUpdateRequest.attributeTypeMap;
     }
 }
 
-export namespace CheckoutSession {
-    export enum TypeEnum {
-        CheckoutSession = <any> 'checkout-session'
-    }
-}

--- a/model/connectionOptionsCybersourceAntiFraud.ts
+++ b/model/connectionOptionsCybersourceAntiFraud.ts
@@ -17,7 +17,7 @@ import { RequestFile } from './models';
 */
 export class ConnectionOptionsCybersourceAntiFraud {
     /**
-    * This is a key-value object for merchant defined data.
+    * This is a key-value object for merchant defined data. Each key needs to be a numeric string identifying the MDD field to set. For example, for field 1 set the key to \"1\".
     */
     'merchantDefinedData'?: { [key: string]: string; };
 

--- a/model/connectionOptionsForterAntiFraud.ts
+++ b/model/connectionOptionsForterAntiFraud.ts
@@ -17,7 +17,7 @@ import { RequestFile } from './models';
 */
 export class ConnectionOptionsForterAntiFraud {
     /**
-    * Value to populate the `deliveryType` field in `primaryDeliveryDetails`.  Represents the type of delivery: PHYSICAL for any type of shipped goods. DIGITAL for non-shipped goods (services, gift cards etc.). Possible values are: \"DIGITAL\", \"PHYSICAL\", \"HYBRID\".
+    * Value to populate the `deliveryType` field in `primaryDeliveryDetails`.  Represents the type of delivery. This can be set to `PHYSICAL` for any type of shipped goods, `DIGITAL` for non-shipped goods (services, gift cards etc.), or `HYBRID` for others.
     */
     'deliveryType'?: string | null;
     /**

--- a/model/models.ts
+++ b/model/models.ts
@@ -39,9 +39,11 @@ export * from './cardSchemeDefinition';
 export * from './cardSchemeDefinitions';
 export * from './cartItem';
 export * from './checkoutSession';
+export * from './checkoutSessionCreateRequest';
 export * from './checkoutSessionFieldsPaymentMethod';
 export * from './checkoutSessionRequest';
 export * from './checkoutSessionSecureFieldsUpdate';
+export * from './checkoutSessionUpdateRequest';
 export * from './connection';
 export * from './connectionDefinition';
 export * from './connectionDefinitions';
@@ -246,9 +248,11 @@ import { CardSchemeDefinition } from './cardSchemeDefinition';
 import { CardSchemeDefinitions } from './cardSchemeDefinitions';
 import { CartItem } from './cartItem';
 import { CheckoutSession } from './checkoutSession';
+import { CheckoutSessionCreateRequest } from './checkoutSessionCreateRequest';
 import { CheckoutSessionFieldsPaymentMethod } from './checkoutSessionFieldsPaymentMethod';
 import { CheckoutSessionRequest } from './checkoutSessionRequest';
 import { CheckoutSessionSecureFieldsUpdate } from './checkoutSessionSecureFieldsUpdate';
+import { CheckoutSessionUpdateRequest } from './checkoutSessionUpdateRequest';
 import { Connection } from './connection';
 import { ConnectionDefinition } from './connectionDefinition';
 import { ConnectionDefinitions } from './connectionDefinitions';
@@ -646,9 +650,11 @@ let typeMap: {[index: string]: any} = {
     "CardSchemeDefinitions": CardSchemeDefinitions,
     "CartItem": CartItem,
     "CheckoutSession": CheckoutSession,
+    "CheckoutSessionCreateRequest": CheckoutSessionCreateRequest,
     "CheckoutSessionFieldsPaymentMethod": CheckoutSessionFieldsPaymentMethod,
     "CheckoutSessionRequest": CheckoutSessionRequest,
     "CheckoutSessionSecureFieldsUpdate": CheckoutSessionSecureFieldsUpdate,
+    "CheckoutSessionUpdateRequest": CheckoutSessionUpdateRequest,
     "Connection": Connection,
     "ConnectionDefinition": ConnectionDefinition,
     "ConnectionDefinitions": ConnectionDefinitions,

--- a/model/paymentMethod.ts
+++ b/model/paymentMethod.ts
@@ -87,6 +87,14 @@ export class PaymentMethod {
     */
     'country'?: string | null;
     'details'?: PaymentMethodDetailsCard;
+    /**
+    * The date and time when this card was last replaced.  When the Account Updater determines that new card details are available (e.g. when it\'s about to expire), existing details are not changed immediately. The actual replacement occurs when a transaction using this payment method is declined with any of the following codes:  * `canceled_payment_method` * `expired_payment_method` * `unavailable_payment_method` * `unknown_payment_method`  When the replacement is applied, this field is updated. For non-card payment methods, the value of this field is always set to `null`.
+    */
+    'lastReplacedAt'?: Date | null;
+    /**
+    * Whether this card has a pending replacement that hasn\'t been applied yet.  When the Account Updater determines that new card details are available (e.g. when it\'s about to expire), existing details are not changed immediately, but this field is set to `true`. The actual replacement occurs when a transaction using this payment method is declined with any of the following codes:  * `canceled_payment_method` * `expired_payment_method` * `unavailable_payment_method` * `unknown_payment_method`  When the replacement is applied, this field is set to `false`. For non-card payment methods, the value of this field is always set to `false`.
+    */
+    'hasReplacement'?: boolean;
 
     static discriminator: string | undefined = undefined;
 
@@ -180,6 +188,16 @@ export class PaymentMethod {
             "name": "details",
             "baseName": "details",
             "type": "PaymentMethodDetailsCard"
+        },
+        {
+            "name": "lastReplacedAt",
+            "baseName": "last_replaced_at",
+            "type": "Date"
+        },
+        {
+            "name": "hasReplacement",
+            "baseName": "has_replacement",
+            "type": "boolean"
         }    ];
 
     static getAttributeTypeMap() {

--- a/model/paymentMethodTokenized.ts
+++ b/model/paymentMethodTokenized.ts
@@ -60,6 +60,14 @@ export class PaymentMethodTokenized {
     * The 2-letter ISO code of the country this payment method can be used for. If this value is `null` the payment method may be used in multiple countries.
     */
     'country'?: string | null;
+    /**
+    * The date and time when this card was last replaced.  When the Account Updater determines that new card details are available (e.g. when it\'s about to expire), existing details are not changed immediately. The actual replacement occurs when a transaction using this payment method is declined with any of the following codes:  * `canceled_payment_method` * `expired_payment_method` * `unavailable_payment_method` * `unknown_payment_method`  When the replacement is applied, this field is updated. For non-card payment methods, the value of this field is always set to `null`.
+    */
+    'lastReplacedAt'?: Date | null;
+    /**
+    * Whether this card has a pending replacement that hasn\'t been applied yet.  When the Account Updater determines that new card details are available (e.g. when it\'s about to expire), existing details are not changed immediately, but this field is set to `true`. The actual replacement occurs when a transaction using this payment method is declined with any of the following codes:  * `canceled_payment_method` * `expired_payment_method` * `unavailable_payment_method` * `unknown_payment_method`  When the replacement is applied, this field is set to `false`. For non-card payment methods, the value of this field is always set to `false`.
+    */
+    'hasReplacement'?: boolean;
 
     static discriminator: string | undefined = undefined;
 
@@ -118,6 +126,16 @@ export class PaymentMethodTokenized {
             "name": "country",
             "baseName": "country",
             "type": "string"
+        },
+        {
+            "name": "lastReplacedAt",
+            "baseName": "last_replaced_at",
+            "type": "Date"
+        },
+        {
+            "name": "hasReplacement",
+            "baseName": "has_replacement",
+            "type": "boolean"
         }    ];
 
     static getAttributeTypeMap() {

--- a/model/transaction.ts
+++ b/model/transaction.ts
@@ -121,6 +121,10 @@ export class Transaction {
     */
     'rawResponseDescription'?: string | null;
     /**
+    * This is the response description received from the processor.
+    */
+    'authResponseCode'?: string | null;
+    /**
     * The response code received from the payment service for the Address Verification Check (AVS). This code is mapped to a standardized Gr4vy AVS response code.  - `no_match` - neither address or postal code match - `match` - both address and postal code match - `partial_match_address` - address matches but postal code does not - `partial_match_postcode` - postal code matches but address does not - `unavailable ` - AVS is unavailable for card/country  The value of this field can be `null` if the payment service did not provide a response.
     */
     'avsResponseCode'?: Transaction.AvsResponseCodeEnum;
@@ -285,6 +289,11 @@ export class Transaction {
         {
             "name": "rawResponseDescription",
             "baseName": "raw_response_description",
+            "type": "string"
+        },
+        {
+            "name": "authResponseCode",
+            "baseName": "auth_response_code",
             "type": "string"
         },
         {

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -43,6 +43,7 @@ class Client {
   newCheckoutSession: typeof CheckoutSessionsApi.prototype.newCheckoutSession
   deleteCheckoutSession: typeof CheckoutSessionsApi.prototype.deleteCheckoutSession
   getCheckoutSession: typeof CheckoutSessionsApi.prototype.getCheckoutSession
+  updateCheckoutSession: typeof CheckoutSessionsApi.prototype.updateCheckoutSession
   updateCheckoutSessionFields: typeof CheckoutSessionsApi.prototype.updateCheckoutSessionFields
 
   // Payment Methods
@@ -113,6 +114,7 @@ class Client {
     this.newCheckoutSession = this.wrap(csa.newCheckoutSession.bind(csa))
     this.deleteCheckoutSession = this.wrap(csa.deleteCheckoutSession.bind(csa))
     this.getCheckoutSession = this.wrap(csa.getCheckoutSession.bind(csa))
+    this.updateCheckoutSession = this.wrap(csa.updateCheckoutSession.bind(csa))
     this.updateCheckoutSessionFields = this.wrap(
       csa.updateCheckoutSessionFields.bind(csa)
     )


### PR DESCRIPTION
Re TA-4928 updates API for use with new checkout session enhancements.

Also adds a few missing properties in latest OpenAPI updates.