### PR TITLE
release: Bump to 0.63.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gr4vy/node",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "NodeJS client for @gr4vy/node",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`0.63.1` has been released but the version wasn't increased as part of the `yarn release` task due to not being able to push directly to `main`. This ensures the version is up-to-date in the `package.json`