### PR TITLE
chore: Fix CI workflow to use Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 14.x
+          - 20.x
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,7 +3,7 @@ name: Releases
 on:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 jobs:
   publish:
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "14.x"
+          node-version: '20.x'
 
       - name: Build the package
         run: |


### PR DESCRIPTION
Release was failing due to v14 no longer being supported https://github.com/gr4vy/gr4vy-node/actions/runs/9758157171/job/26932117069